### PR TITLE
Support android 4.3 again

### DIFF
--- a/android/src/main/java/com/github/alinz/reactnativewebviewbridge/StatusBridge.java
+++ b/android/src/main/java/com/github/alinz/reactnativewebviewbridge/StatusBridge.java
@@ -1,6 +1,7 @@
 package com.github.alinz.reactnativewebviewbridge;
 
 import android.webkit.JavascriptInterface;
+import android.webkit.ValueCallback;
 import android.webkit.WebView;
 import android.app.Activity;
 
@@ -50,7 +51,7 @@ class StatusBridge {
                     activity.runOnUiThread(new Runnable() {
                         @Override
                         public void run() {
-                            webView.evaluateJavascript(script, null);
+                            evaluateJavascript(webView, script);
                         }
                     });
                 } catch (IOException e) {
@@ -78,6 +79,14 @@ class StatusBridge {
             e.printStackTrace();
 
             return "";
+        }
+    }
+
+    static private void evaluateJavascript(WebView root, String javascript) {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
+            root.evaluateJavascript(javascript, null);
+        } else {
+            root.loadUrl("javascript:" + javascript);
         }
     }
 }

--- a/android/src/main/java/com/github/alinz/reactnativewebviewbridge/WebViewBridgeManager.java
+++ b/android/src/main/java/com/github/alinz/reactnativewebviewbridge/WebViewBridgeManager.java
@@ -143,12 +143,12 @@ public class WebViewBridgeManager extends ReactWebViewManager {
 
     private void sendToBridge(WebView root, String message) {
         String script = "WebViewBridge.onMessage('" + message + "');";
-        WebViewBridgeManager.evaluateJavascript(root, script);
+        WebViewBridgeManager.evaluateJavascript(root, script, null);
     }
 
-    static private void evaluateJavascript(WebView root, String javascript) {
+    static private void evaluateJavascript(WebView root, String javascript, ValueCallback<String> callback) {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
-            root.evaluateJavascript(javascript, null);
+            root.evaluateJavascript(javascript, callback);
         } else {
             root.loadUrl("javascript:" + javascript);
         }
@@ -275,7 +275,7 @@ public class WebViewBridgeManager extends ReactWebViewManager {
         public void callInjectedOnStartLoadingJavaScript() {
             if (injectedOnStartLoadingJS != null &&
                     !TextUtils.isEmpty(injectedOnStartLoadingJS)) {
-                evaluateJavascript(injectedOnStartLoadingJS, new ValueCallback<String>() {
+                WebViewBridgeManager.evaluateJavascript(this,injectedOnStartLoadingJS, new ValueCallback<String>() {
                             @Override
                             public void onReceiveValue(String value) {
 
@@ -290,7 +290,7 @@ public class WebViewBridgeManager extends ReactWebViewManager {
                 if (ReactBuildConfig.DEBUG && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
                     // See isNative in lodash
                     String testPostMessageNative = "String(window.postMessage) === String(Object.hasOwnProperty).replace('hasOwnProperty', 'postMessage')";
-                    evaluateJavascript(testPostMessageNative, new ValueCallback<String>() {
+                    WebViewBridgeManager.evaluateJavascript(this,testPostMessageNative, new ValueCallback<String>() {
                         @Override
                         public void onReceiveValue(String value) {
                             if (value.equals("true")) {


### PR DESCRIPTION
Workaround for WebView.evaluateJavascript so that code can run in
android 4.3 too.

Not the cleanest patch (a bit of code duplication), but now Status doesn't crash anymore on my Galaxy S3.